### PR TITLE
Added StreamExt::timeout_once()

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -10,6 +10,7 @@ mod sample;
 mod stream_ext;
 mod throttle;
 mod timeout;
+mod timeout_once;
 
 pub use buffer::Buffer;
 pub use debounce::Debounce;
@@ -21,3 +22,4 @@ pub use sample::Sample;
 pub use stream_ext::StreamExt;
 pub use throttle::Throttle;
 pub use timeout::Timeout;
+pub use timeout_once::TimeoutOnce;

--- a/src/stream/timeout_once.rs
+++ b/src/stream/timeout_once.rs
@@ -1,0 +1,47 @@
+use core::future::Future;
+use std::io;
+use std::pin::Pin;
+
+use pin_project_lite::pin_project;
+
+use core::task::{Context, Poll};
+use futures_core::stream::Stream;
+
+use crate::utils;
+
+pin_project! {
+    /// A stream with timeout time set
+    ///
+    /// This `struct` is created by the [`timeout_once`] method on [`StreamExt`]. See its
+    /// documentation for more.
+    ///
+    /// [`timeout_once`]: crate::stream::StreamExt::timeout_once
+    /// [`StreamExt`]: crate::stream::StreamExt
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled or .awaited"]
+    pub struct TimeoutOnce<S, D> {
+        #[pin]
+        stream: S,
+        #[pin]
+        deadline: D,
+    }
+}
+
+impl<S, D> TimeoutOnce<S, D> {
+    pub(crate) fn new(stream: S, deadline: D) -> Self {
+        Self { stream, deadline }
+    }
+}
+
+impl<S: Stream, D: Future> Stream for TimeoutOnce<S, D> {
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        match this.deadline.as_mut().poll(cx) {
+            Poll::Ready(_) => Poll::Ready(None),
+            Poll::Pending => this.stream.poll_next(cx),
+        }
+    }
+}


### PR DESCRIPTION
# What
- Adds a method `StreamExt::timeout_once()` which stops a `Stream` after the given timeout future resolves once, without resets.
- Adds clarifying examples that differentiate `timeout()` and `timeout_once()`

# Why
`StreamExt::timeout()` stops a `Stream` if a given `Future` expires before the next stream value is produced, but resets that timer each time a new value is produced. This is useful, but doesn't guarantee a way to turn an infinite stream into a finite one based on time.

I needed a way to stop a stream after a certain amount of time has progressed in total (i.e., without resetting the timer), so I wrote this `.timeout_once()` method that waits until the given timeout expires _once_, and then stops the stream without error.

# Request for comments
I'm open to name changes or further modifications. 

This change satisfies what I need for my project, but hopefully this is useful to others!